### PR TITLE
Fixes to Pg Kafka-Connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <configuration>
           <compilerArgs>
             <arg>-Xlint:all</arg>
-            <arg>-Werror</arg>
+            <!--<arg>-Werror</arg>-->
           </compilerArgs>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <configuration>
           <compilerArgs>
             <arg>-Xlint:all</arg>
-            <!--<arg>-Werror</arg>-->
+            <arg>-Werror</arg>
           </compilerArgs>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <groupId>io.confluent</groupId>
   <artifactId>kafka-connect-jdbc-au</artifactId>
 
-  <version>5.0.0-au</version>
+  <version>5.0.5-au</version>
   <packaging>jar</packaging>
   <name>kafka-connect-jdbc</name>
   <description>A Kafka Connect JDBC connector for copying data between databases and Kafka. Modified with some Au patches</description>

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.jdbc;
 
+import io.confluent.connect.jdbc.source.NoOpTableMonitorThread;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.Task;
@@ -117,14 +118,25 @@ public class JdbcSourceConnector extends SourceConnector {
       whitelistSet = Collections.emptySet();
 
     }
-    tableMonitorThread = new TableMonitorThread(
-        dialect,
-        cachedConnectionProvider,
-        context,
-        tablePollMs,
-        whitelistSet,
-        blacklistSet
-    );
+    if (config.getBoolean(JdbcSourceConnectorConfig.ENABLE_TABLE_MONITOR)) {
+      tableMonitorThread = new TableMonitorThread(
+              dialect,
+              cachedConnectionProvider,
+              context,
+              tablePollMs,
+              whitelistSet,
+              blacklistSet
+      );
+    } else {
+      tableMonitorThread = new NoOpTableMonitorThread(
+              dialect,
+              cachedConnectionProvider,
+              context,
+              tablePollMs,
+              whitelistSet,
+              blacklistSet
+      );
+    }
     tableMonitorThread.start();
   }
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -17,6 +17,7 @@
 package io.confluent.connect.jdbc.dialect;
 
 import io.confluent.connect.jdbc.source.JdbcSourceTaskConfig;
+import io.confluent.connect.jdbc.util.PreparedStatementProxy;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -80,24 +81,18 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     return connection;
   }
 
-  /**
-   * Perform any operations on a {@link PreparedStatement} before it is used. This is called from
-   * the {@link #createPreparedStatement(Connection, String)} method after the statement is
-   * created but before it is returned/used.
-   *
-   * <p>This method sets the {@link PreparedStatement#setFetchDirection(int) fetch direction}
-   * to {@link ResultSet#FETCH_FORWARD forward} as an optimization for the driver to allow it to
-   * scroll more efficiently through the result set and prevent out of memory errors.
-   *
-   * @param stmt the prepared statement; never null
-   * @throws SQLException the error that might result from initialization
-   */
   @Override
-  protected void initializePreparedStatement(PreparedStatement stmt) throws SQLException {
+  public PreparedStatement createPreparedStatement(Connection db, String query)
+          throws SQLException {
+    log.trace("Creating a PreparedStatement '{}'", query);
+
+    PreparedStatement stmt = db.prepareStatement(query);
     int batchMaxRows = config.getInt(JdbcSourceTaskConfig.BATCH_MAX_ROWS_CONFIG);
     log.trace("Initializing PreparedStatement fetch direction to FETCH_FORWARD for '{}'", stmt);
     stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
     stmt.setFetchSize(batchMaxRows);
+
+    return PreparedStatementProxy.newInstance(stmt);
   }
 
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -76,9 +76,7 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
 
   @Override
   public Connection getConnection() throws SQLException {
-    Connection connection = super.getConnection();
-    connection.setAutoCommit(false);
-    return connection;
+    return super.getConnection();
   }
 
   @Override
@@ -87,8 +85,10 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
     log.trace("Creating a PreparedStatement '{}'", query);
 
     PreparedStatement stmt = db.prepareStatement(query);
-    int batchMaxRows = config.getInt(JdbcSourceTaskConfig.BATCH_MAX_ROWS_CONFIG);
+
+    final int batchMaxRows = config.getInt(JdbcSourceTaskConfig.BATCH_MAX_ROWS_CONFIG);
     log.trace("Initializing PreparedStatement fetch direction to FETCH_FORWARD for '{}'", stmt);
+    stmt.getConnection().setAutoCommit(false);
     stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
     stmt.setFetchSize(batchMaxRows);
 

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -127,6 +127,13 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
       + "specific dialect. All properly-packaged dialects in the JDBC connector plugin "
       + "can be used.";
 
+  public static final String ENABLE_TABLE_MONITOR = "table-monitor.enable";
+  public static final boolean ENABLE_TABLE_MONITOR_DEFAULT = false;
+  private static final String ENABLE_TABLE_MONITOR_DOC =
+          "The table monitor thread occasionally examines the schema of the underlying database" +
+          " to determine if kafka-connect should create connectors for additional tables. Enable " +
+          " if you wish to use dynamic table discovery.";
+
   public static final String MODE_CONFIG = "mode";
   private static final String MODE_DOC =
       "The mode for updating a table each time it is polled. Options include:\n"
@@ -405,7 +412,13 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         ++orderInGroup,
         Width.LONG,
         DIALECT_NAME_DISPLAY,
-        DatabaseDialectRecommender.INSTANCE);
+        DatabaseDialectRecommender.INSTANCE
+    ).define(
+        ENABLE_TABLE_MONITOR,
+        Type.BOOLEAN,
+        ENABLE_TABLE_MONITOR_DEFAULT,
+        Importance.MEDIUM,
+        ENABLE_TABLE_MONITOR_DOC);
   }
 
   private static final void addModeOptions(ConfigDef config) {

--- a/src/main/java/io/confluent/connect/jdbc/source/NoOpTableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/NoOpTableMonitorThread.java
@@ -1,0 +1,45 @@
+package io.confluent.connect.jdbc.source;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialect;
+import io.confluent.connect.jdbc.util.ConnectionProvider;
+import io.confluent.connect.jdbc.util.TableId;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.kafka.connect.connector.ConnectorContext;
+
+public class NoOpTableMonitorThread extends TableMonitorThread {
+
+    AtomicBoolean running = new AtomicBoolean(true);
+
+    public NoOpTableMonitorThread(DatabaseDialect dialect,
+                                  ConnectionProvider connectionProvider,
+                                  ConnectorContext context,
+                                  long pollMs,
+                                  Set<String> whitelist,
+                                  Set<String> blacklist) {
+        super(dialect, connectionProvider, context, pollMs, whitelist, blacklist);
+    }
+
+    @Override
+    public void run() {
+        while (running.get()) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                break;
+            }
+        }
+    }
+
+    @Override
+    public synchronized List<TableId> tables() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void shutdown() {
+        running.set(false);
+    }
+}

--- a/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableQuerier.java
@@ -25,6 +25,8 @@ import java.sql.SQLException;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.util.TableId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * TableQuerier executes queries against a specific table. Implementations handle different types
@@ -32,6 +34,10 @@ import io.confluent.connect.jdbc.util.TableId;
  * loads using timestamps, etc.
  */
 abstract class TableQuerier implements Comparable<TableQuerier> {
+
+  private static final Logger log = LoggerFactory.getLogger(TableQuerier.class);
+
+
   public enum QueryMode {
     TABLE, // Copying whole tables, with queries constructed automatically
     QUERY // User-specified query
@@ -112,8 +118,10 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
     if (stmt != null) {
       try {
         stmt.close();
-      } catch (SQLException ignored) {
-        // intentionally ignored
+      } catch (SQLException e) {
+        log.warn("failed to close statement quietly, {}, {}",
+                 e.getClass().getName(),
+                 e.getMessage());
       }
     }
     stmt = null;
@@ -123,8 +131,10 @@ abstract class TableQuerier implements Comparable<TableQuerier> {
     if (resultSet != null) {
       try {
         resultSet.close();
-      } catch (SQLException ignored) {
-        // intentionally ignored
+      } catch (SQLException e) {
+        log.warn("failed to close resultSet quietly, {}, {}",
+                 e.getClass().getName(),
+                 e.getMessage());
       }
     }
     resultSet = null;

--- a/src/main/java/io/confluent/connect/jdbc/util/PreparedStatementProxy.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/PreparedStatementProxy.java
@@ -1,0 +1,62 @@
+
+package io.confluent.connect.jdbc.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PreparedStatementProxy implements java.lang.reflect.InvocationHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(PreparedStatementProxy.class);
+
+    private PreparedStatement ps;
+
+    public static PreparedStatement newInstance(PreparedStatement stmt) {
+        return (PreparedStatement) java.lang.reflect.Proxy.newProxyInstance(
+                stmt.getClass().getClassLoader(),
+                stmt.getClass().getInterfaces(),
+                new PreparedStatementProxy(stmt));
+    }
+
+    private PreparedStatementProxy(PreparedStatement ps) {
+        this.ps = ps;
+    }
+
+    public Object invoke(Object proxy, Method m, Object[] args) throws Throwable {
+        log.trace("proxy called {}", m.getName());
+
+        Object result;
+        try {
+            result = m.invoke(ps, args);
+
+            if (m.getName().equals("close")) {
+                tryCommit();
+            }
+
+        } catch (InvocationTargetException e) {
+            throw e.getTargetException();
+        } catch (Exception e) {
+            log.error("{} during transaction commit: {}",
+                      e.getClass().getName(),
+                      e.getMessage());
+
+            throw new RuntimeException("unexpected invocation exception: " + e.getMessage());
+        }
+
+        return result;
+    }
+
+    private void tryCommit() {
+        try {
+            ps.getConnection().commit();
+        } catch (SQLException e) {
+            log.warn("proxy failed to commit on statement close, {}", e.getMessage());
+            log.trace("{}", e);
+            // swallow exception
+        }
+    }
+
+}

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSourceConnectorTest.java
@@ -68,6 +68,7 @@ public class JdbcSourceConnectorTest {
     connProps.put(JdbcSourceConnectorConfig.CONNECTION_URL_CONFIG, db.getUrl());
     connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_BULK);
     connProps.put(JdbcSourceConnectorConfig.TOPIC_PREFIX_CONFIG, "test-");
+    connProps.put(JdbcSourceConnectorConfig.ENABLE_TABLE_MONITOR, "true");
   }
 
   @After

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -14,6 +14,10 @@
 
 package io.confluent.connect.jdbc.dialect;
 
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -27,12 +31,38 @@ import java.util.List;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDatabaseDialect> {
 
   @Override
   protected PostgreSqlDatabaseDialect createDialect() {
     return new PostgreSqlDatabaseDialect(sourceConfigWithUrl("jdbc:postgresql://something"));
+  }
+
+  @Test
+  public void commitOnPreparedStatementClose() throws SQLException {
+    Connection mockConnection = mock(Connection.class);
+    PreparedStatement mockPreparedStatement = mock(PreparedStatement.class);
+    final String query = "SELECT * FROM test";
+    when(mockConnection.prepareStatement(eq(query)))
+            .thenReturn(mockPreparedStatement);
+    when(mockPreparedStatement.getConnection())
+            .thenReturn(mockConnection);
+
+    PreparedStatement stmtProxy =
+            dialect.createPreparedStatement(mockConnection, query);
+
+    assertTrue(stmtProxy instanceof Proxy);
+
+    stmtProxy.close();
+
+    verify(mockConnection, times(1)).commit();
   }
 
   @Test


### PR DESCRIPTION
1. Proxy PreparedStatement to commit TXN on statement close

To fix a OOM error, we set the pg connection's `autoCommit` setting to `false`. This allows the underlying cursor to fetch small sets of rows instead of the entire table, like it does when autocommit is `true`.

This caused issues down the line as when the PreparedStatement was closed after executing a query, the connection never committed which causes the connection to hold read locks on the queried tables. We would see this when querying the `pg_stat_activity` table revealing 2 pid's which were stuck in `idle in transaction` state.

I added a proxy to the prepared statement to commit the transaction on close.

2. Disable TableMonitor

Kafka connect has a setting where it dumps an entire database into a kafka topic dynamically. It continuously queries the catalog to discover new tables.

The queries to the catalog table use the same connection as the queries for records to dump to kafka. This means they had the same problem with being stuck in `idle in transaction` state as the connection was never committed.

We don't actually use this feature, so I'm turning it off by default and adding a NoOpMonitorThread as not to interfere with the existing code.